### PR TITLE
Feat/30  달력에 일정 있는지 여부 표시하기

### DIFF
--- a/src/apis/fetchTaskData.ts
+++ b/src/apis/fetchTaskData.ts
@@ -1,0 +1,8 @@
+import { TaskInfo, TaskInfoListResponse } from '@/types/routine';
+import { axiosCustom } from './createAxios';
+
+export async function fetchTaskData(year: number, month: number) {
+  return await axiosCustom
+    .get<TaskInfoListResponse[]>('tasks/list', { params: { year, month } })
+    .then((res) => res.data);
+}

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -44,7 +44,7 @@ const Calendar = () => {
       ? 53
       : today.clone().endOf('month').week();
 
-  // calendarArr 함수: 캘린더 테이블을 생성하는 함수입니다.
+  // calendarArr 함수: 캘린더 테이블을 생성하는 함수입니다. -> 나중에 분리할 것
   const calendarArr = (): JSX.Element[] => {
     let result: JSX.Element[] = [];
     let week = firstWeek;


### PR DESCRIPTION
## 추가한 기능 설명
오늘날짜 표시 색 노랑으로 변경
API로 불러온 데이터 해당 날짜에 있을 시 붉은 점 표기

<br>
<img width="372" alt="스크린샷 2023-04-12 오후 5 58 00" src="https://user-images.githubusercontent.com/54524378/231407109-b10ba7fc-86bd-41fe-948a-39e97af32a1f.png">


## check list
- [ ] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?
